### PR TITLE
Fixes SQL Warnings during PesaYetu migrations

### DIFF
--- a/pesayetu/sql/ceilings_on_expenditure.sql
+++ b/pesayetu/sql/ceilings_on_expenditure.sql
@@ -16,6 +16,9 @@ SET row_security = off;
 
 SET search_path = public, pg_catalog;
 
+ALTER TABLE IF EXISTS ONLY public.expenditure_year DROP CONSTRAINT IF EXISTS pk_expenditure_year;
+DROP TABLE IF EXISTS public.expenditure_year;
+
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/pesayetu/sql/conditional_funds_2015_2016.sql
+++ b/pesayetu/sql/conditional_funds_2015_2016.sql
@@ -16,6 +16,8 @@ SET row_security = off;
 
 SET search_path = public, pg_catalog;
 
+ALTER TABLE IF EXISTS ONLY public.conditional_fund DROP CONSTRAINT IF EXISTS pk_conditional_fund;
+DROP TABLE IF EXISTS public.conditional_fund;
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/pesayetu/sql/equitable_allocations.sql
+++ b/pesayetu/sql/equitable_allocations.sql
@@ -16,6 +16,9 @@ SET row_security = off;
 
 SET search_path = public, pg_catalog;
 
+ALTER TABLE IF EXISTS ONLY public.financial_year DROP CONSTRAINT IF EXISTS pk_financial_year;
+DROP TABLE IF EXISTS public.financial_year;
+
 SET default_tablespace = '';
 
 SET default_with_oids = false;


### PR DESCRIPTION
## Description

Add missing DROP TABLE IF EXISTS statements

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
