### PR TITLE
Fixes SQL Warnings during HURUmap TZ migrations

### DIFF
--- a/hurumap_tz/sql/airporttypes.sql
+++ b/hurumap_tz/sql/airporttypes.sql
@@ -16,6 +16,8 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
 
+ALTER TABLE IF EXISTS ONLY public.airporttypes DROP CONSTRAINT IF EXISTS pk_airporttypes;
+DROP TABLE IF EXISTS public.airporttypes;
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -33,8 +35,6 @@ CREATE TABLE public.airporttypes (
     total integer
 );
 
-
-ALTER TABLE public.airporttypes OWNER TO hurumap_tz;
 
 --
 -- TOC entry 2265 (class 0 OID 29052)

--- a/hurumap_tz/sql/hivcenters.sql
+++ b/hurumap_tz/sql/hivcenters.sql
@@ -15,6 +15,8 @@ SET row_security = off;
 
 SET search_path = public, pg_catalog;
 
+ALTER TABLE IF EXISTS ONLY public.hivcenters DROP CONSTRAINT IF EXISTS pk_hivcenters;
+DROP TABLE IF EXISTS public.hivcenters;
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -31,8 +33,6 @@ CREATE TABLE hivcenters (
     geo_version character varying(100) DEFAULT ''::character varying NOT NULL
 );
 
-
-ALTER TABLE hivcenters OWNER TO hurumap_tz;
 
 --
 -- Data for Name: hivcenters; Type: TABLE DATA; Schema: public; Owner: hurumap_tz

--- a/hurumap_tz/sql/primaryschoolteachers.sql
+++ b/hurumap_tz/sql/primaryschoolteachers.sql
@@ -15,6 +15,8 @@ SET row_security = off;
 
 SET search_path = public, pg_catalog;
 
+ALTER TABLE IF EXISTS ONLY public.primaryschoolteachers DROP CONSTRAINT IF EXISTS pk_primaryschoolteachers;
+DROP TABLE IF EXISTS public.primaryschoolteachers;
 SET default_tablespace = '';
 
 SET default_with_oids = false;

--- a/hurumap_tz/sql/watersources.sql
+++ b/hurumap_tz/sql/watersources.sql
@@ -15,6 +15,8 @@ SET row_security = off;
 
 SET search_path = public, pg_catalog;
 
+ALTER TABLE IF EXISTS ONLY public.watersources DROP CONSTRAINT IF EXISTS pk_watersources;
+DROP TABLE IF EXISTS public.watersources;
 SET default_tablespace = '';
 
 SET default_with_oids = false;


### PR DESCRIPTION
## Description

Add missing `DROP TABLE IF EXISTS` statements

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
