### PR TITLE
Fixes SQL Warnings during HURUmap ZM migrations

### DIFF
--- a/hurumap_zm/sql/agegroup_gender.sql
+++ b/hurumap_zm/sql/agegroup_gender.sql
@@ -7,21 +7,21 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
 SET search_path = public, pg_catalog;
 
+ALTER TABLE IF EXISTS ONLY public.agegroup_gender DROP CONSTRAINT IF EXISTS pk_agegroup_gender;
+DROP TABLE IF EXISTS public.agegroup_gender;
 SET default_tablespace = '';
 
 SET default_with_oids = false;
 
 --
--- Name: agegroup_gender; Type: TABLE; Schema: public; Owner: hurumap_zm
+-- Name: agegroup_gender; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE agegroup_gender (
@@ -34,10 +34,8 @@ CREATE TABLE agegroup_gender (
 );
 
 
-ALTER TABLE agegroup_gender OWNER TO hurumap_zm;
-
 --
--- Data for Name: agegroup_gender; Type: TABLE DATA; Schema: public; Owner: hurumap_zm
+-- Data for Name: agegroup_gender; Type: TABLE DATA; Schema: public; Owner: -
 --
 
 COPY agegroup_gender (geo_level, geo_code, gender, "age group", total, geo_version) FROM stdin;
@@ -115,7 +113,7 @@ province	10	female	35 and above	100829	2010
 --
 
 ALTER TABLE ONLY agegroup_gender
-    ADD CONSTRAINT agegroup_gender_pkey PRIMARY KEY (geo_level, geo_code, gender, "age group");
+    ADD CONSTRAINT pk_agegroup_gender PRIMARY KEY (geo_level, geo_code, gender, "age group");
 
 
 --

--- a/hurumap_zm/sql/gender_ruralorurban.sql
+++ b/hurumap_zm/sql/gender_ruralorurban.sql
@@ -7,21 +7,21 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
 SET search_path = public, pg_catalog;
 
+ALTER TABLE IF EXISTS ONLY public.gender_ruralorurban DROP CONSTRAINT IF EXISTS pk_gender_ruralorurban;
+DROP TABLE IF EXISTS public.gender_ruralorurban;
 SET default_tablespace = '';
 
 SET default_with_oids = false;
 
 --
--- Name: gender_ruralorurban; Type: TABLE; Schema: public; Owner: hurumap_zm
+-- Name: gender_ruralorurban; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE gender_ruralorurban (
@@ -34,10 +34,8 @@ CREATE TABLE gender_ruralorurban (
 );
 
 
-ALTER TABLE gender_ruralorurban OWNER TO hurumap_zm;
-
 --
--- Data for Name: gender_ruralorurban; Type: TABLE DATA; Schema: public; Owner: hurumap_zm
+-- Data for Name: gender_ruralorurban; Type: TABLE DATA; Schema: public; Owner: -
 --
 
 COPY gender_ruralorurban (geo_level, geo_code, gender, "rural or urban", total, geo_version) FROM stdin;
@@ -93,7 +91,7 @@ province	10	female	urban	59547	2010
 --
 
 ALTER TABLE ONLY gender_ruralorurban
-    ADD CONSTRAINT gender_ruralorurban_pkey PRIMARY KEY (geo_level, geo_code, gender, "rural or urban");
+    ADD CONSTRAINT pk_gender_ruralorurban PRIMARY KEY (geo_level, geo_code, gender, "rural or urban");
 
 
 --

--- a/hurumap_zm/sql/gender_ruralurban.sql
+++ b/hurumap_zm/sql/gender_ruralurban.sql
@@ -7,7 +7,7 @@ SET client_min_messages = warning;
 
 SET search_path = public, pg_catalog;
 
-ALTER TABLE IF EXISTS ONLY public.gender_ruralorurban DROP CONSTRAINT IF EXISTS gender_ruralorurban_pkey;
+ALTER TABLE IF EXISTS ONLY public.gender_ruralorurban DROP CONSTRAINT IF EXISTS pk_gender_ruralorurban;
 DROP TABLE IF EXISTS public.gender_ruralorurban;
 SET search_path = public, pg_catalog;
 
@@ -24,7 +24,8 @@ CREATE TABLE gender_ruralorurban (
     geo_code character varying(10) NOT NULL,
     gender character varying(128) NOT NULL,
     "rural or urban" character varying(128) NOT NULL,
-    total integer NOT NULL
+    total integer NOT NULL,
+    geo_version character varying(100)
 );
 
 
@@ -33,51 +34,51 @@ CREATE TABLE gender_ruralorurban (
 --
 
 
-COPY gender_ruralorurban (geo_level, geo_code, gender, "rural or urban", total) FROM stdin;
-country	ZM	male	rural	3664349
-province	1	male	rural	460146
-province	2	male	rural	181734
-province	3	male	rural	651737
-province	4	male	rural	367462
-province	5	male	rural	160216
-province	6	male	rural	272884
-province	7	male	rural	415508
-province	8	male	rural	256167
-province	9	male	rural	556592
-province	10	male	rural	341903
-country	ZM	female	rural	3840943
-province	1	female	rural	468896
-province	2	female	rural	179918
-province	3	female	rural	681706
-province	4	female	rural	388889
-province	5	female	rural	159516
-province	6	female	rural	289141
-province	7	female	rural	437455
-province	8	female	rural	268989
-province	9	female	rural	584948
-province	10	female	rural	381485
-country	ZM	male	urban	2452904
-province	1	male	urban	153226
-province	2	male	urban	769041
-province	3	male	urban	92617
-province	4	male	urban	87584
-province	5	male	urban	888999
-province	6	male	urban	56096
-province	7	male	urban	92718
-province	8	male	urban	76209
-province	9	male	urban	182404
-province	10	male	urban	54010
-country	ZM	female	urban	2568118
-province	1	female	urban	162821
-province	2	female	urban	789918
-province	3	female	urban	99063
-province	4	female	urban	94456
-province	5	female	urban	930176
-province	6	female	urban	59386
-province	7	female	urban	99274
-province	8	female	urban	80333
-province	9	female	urban	193144
-province	10	female	urban	59547
+COPY gender_ruralorurban (geo_level, geo_code, gender, "rural or urban", total, geo_version) FROM stdin;
+country	ZM	male	rural	3664349	2010
+province	1	male	rural	460146	2010
+province	2	male	rural	181734	2010
+province	3	male	rural	651737	2010
+province	4	male	rural	367462	2010
+province	5	male	rural	160216	2010
+province	6	male	rural	272884	2010
+province	7	male	rural	415508	2010
+province	8	male	rural	256167	2010
+province	9	male	rural	556592	2010
+province	10	male	rural	341903	2010
+country	ZM	female	rural	3840943	2010
+province	1	female	rural	468896	2010
+province	2	female	rural	179918	2010
+province	3	female	rural	681706	2010
+province	4	female	rural	388889	2010
+province	5	female	rural	159516	2010
+province	6	female	rural	289141	2010
+province	7	female	rural	437455	2010
+province	8	female	rural	268989	2010
+province	9	female	rural	584948	2010
+province	10	female	rural	381485	2010
+country	ZM	male	urban	2452904	2010
+province	1	male	urban	153226	2010
+province	2	male	urban	769041	2010
+province	3	male	urban	92617	2010
+province	4	male	urban	87584	2010
+province	5	male	urban	888999	2010
+province	6	male	urban	56096	2010
+province	7	male	urban	92718	2010
+province	8	male	urban	76209	2010
+province	9	male	urban	182404	2010
+province	10	male	urban	54010	2010
+country	ZM	female	urban	2568118	2010
+province	1	female	urban	162821	2010
+province	2	female	urban	789918	2010
+province	3	female	urban	99063	2010
+province	4	female	urban	94456	2010
+province	5	female	urban	930176	2010
+province	6	female	urban	59386	2010
+province	7	female	urban	99274	2010
+province	8	female	urban	80333	2010
+province	9	female	urban	193144	2010
+province	10	female	urban	59547	2010
 \.
 
 
@@ -86,7 +87,7 @@ province	10	female	urban	59547
 --
 
 ALTER TABLE ONLY gender_ruralorurban
-    ADD CONSTRAINT gender_ruralorurban_pkey PRIMARY KEY (geo_level, geo_code, gender, "rural or urban");
+    ADD CONSTRAINT pk_gender_ruralorurban PRIMARY KEY (geo_level, geo_code, gender, "rural or urban");
 
 
 --

--- a/hurumap_zm/sql/wazimap_geography.sql
+++ b/hurumap_zm/sql/wazimap_geography.sql
@@ -7,21 +7,30 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
-SET row_security = off;
 
 SET search_path = public, pg_catalog;
 
+DROP INDEX IF EXISTS public.wazimap_geography_version_01953818_like;
+DROP INDEX IF EXISTS public.wazimap_geography_name_36b79089_like;
+DROP INDEX IF EXISTS public.wazimap_geography_long_name_9b8409f5_like;
+DROP INDEX IF EXISTS public.wazimap_geography_b068931c;
+DROP INDEX IF EXISTS public.wazimap_geography_2fc6351a;
+DROP INDEX IF EXISTS public.wazimap_geography_2af72f10;
+ALTER TABLE IF EXISTS ONLY public.wazimap_geography DROP CONSTRAINT IF EXISTS wazimap_geography_pkey;
+ALTER TABLE IF EXISTS ONLY public.wazimap_geography DROP CONSTRAINT IF EXISTS wazimap_geography_geo_level_bbe3c9fc_uniq;
+ALTER TABLE IF EXISTS public.wazimap_geography ALTER COLUMN id DROP DEFAULT;
+DROP SEQUENCE IF EXISTS public.wazimap_geography_id_seq;
+DROP TABLE IF EXISTS public.wazimap_geography;
 SET default_tablespace = '';
 
 SET default_with_oids = false;
 
 --
--- Name: wazimap_geography; Type: TABLE; Schema: public; Owner: hurumap_zm
+-- Name: wazimap_geography; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE wazimap_geography (
@@ -29,18 +38,16 @@ CREATE TABLE wazimap_geography (
     geo_level character varying(15) NOT NULL,
     geo_code character varying(10) NOT NULL,
     name character varying(100) NOT NULL,
-    version integer,
     square_kms double precision,
     parent_level character varying(15),
     parent_code character varying(10),
-    long_name character varying(100)
+    long_name character varying(100),
+    version character varying(100) NOT NULL
 );
 
 
-ALTER TABLE wazimap_geography OWNER TO hurumap_zm;
-
 --
--- Name: wazimap_geography_id_seq; Type: SEQUENCE; Schema: public; Owner: hurumap_zm
+-- Name: wazimap_geography_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE wazimap_geography_id_seq
@@ -51,17 +58,15 @@ CREATE SEQUENCE wazimap_geography_id_seq
     CACHE 1;
 
 
-ALTER TABLE wazimap_geography_id_seq OWNER TO hurumap_zm;
-
 --
--- Name: wazimap_geography_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: hurumap_zm
+-- Name: wazimap_geography_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE wazimap_geography_id_seq OWNED BY wazimap_geography.id;
 
 
 --
--- Name: wazimap_geography id; Type: DEFAULT; Schema: public; Owner: hurumap_zm
+-- Name: wazimap_geography id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY wazimap_geography ALTER COLUMN id SET DEFAULT nextval('wazimap_geography_id_seq'::regclass);


### PR DESCRIPTION
## Description

Add missing `DROP TABLE IF EXISTS` statements
Add missing `geo_version` column to `gender_ruralorurban`
Standard PK names to other HURUmap apps.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
