### PR TITLE
Make docker-entrypoint.sh executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ EXPOSE 8000
 # Copy entrypoint script into the image
 WORKDIR $APP_SRVPROJ
 COPY ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Description

Deployment was failing with `Error response from daemon: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"exec: \\\"/docker-entrypoint.sh\\\": permission denied\"\n"`


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation