### PR TITLE
DATABASE_URL database name should match POSTGRES_DB [162405473]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - POSTGRES_USER=hurumap
       - POSTGRES_PASSWORD=hurumap
-      - POSTGRES_DB=hurumap
+      - POSTGRES_DB=${HURUMAP_APP:-hurumap_land}
       - PGUSER=hurumap
       - PGPASSWORD=hurumap
 


### PR DESCRIPTION
## Description

Change `POSTGRES_DB` to match `DATABASE_URL` database name.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

Missmatched names caused connection exception

![screenshot from 2018-12-04 08-32-27](https://user-images.githubusercontent.com/1779590/49421105-99620a00-f79f-11e8-9094-5f5b99a4fe22.png)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
