### PR TITLE
[Dominion][Bug] Fix map tiles and draw children level

### DIFF
--- a/dominion/static/js/profile_map_mapit.js
+++ b/dominion/static/js/profile_map_mapit.js
@@ -88,7 +88,7 @@ var ProfileMaps = function() {
 
     this.addImagery = function() {
         // add imagery
-        L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        L.tileLayer('//tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png', {
           attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
           subdomains: 'abc',
           maxZoom: 17

--- a/dominion/static/js/profile_map_mapit.js
+++ b/dominion/static/js/profile_map_mapit.js
@@ -88,7 +88,7 @@ var ProfileMaps = function() {
 
     this.addImagery = function() {
         // add imagery
-        L.tileLayer('//{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png', {
+        L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
           attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
           subdomains: 'abc',
           maxZoom: 17

--- a/dominion/templates/country_page.html
+++ b/dominion/templates/country_page.html
@@ -29,7 +29,7 @@ Compare places using tables and maps, download data, and embed charts on your si
         $(function() {
             var maps = new ProfileMaps();
             var zoom = {{country.zoom}};
-            maps.drawMapForCountryPage({{ geography|jsonify|safe }}, {{country.centre}}, zoom);
+            maps.drawMapForCountryPage({{ geography.this |jsonify|safe }}, {{country.centre}}, zoom);
         })
     </script>
 {% endblock %}


### PR DESCRIPTION
## Description

`wmflabs tile` for map returns an ssl error on production. So we have switched to `openstreetmap` tiles till we find a solution

![Screenshot from 2019-03-12 08-50-23](https://user-images.githubusercontent.com/7962097/54177804-92384f80-44a4-11e9-8823-1caa58b9e584.png)
![Screenshot from 2019-03-12 08-50-53](https://user-images.githubusercontent.com/7962097/54177819-982e3080-44a4-11e9-8b8f-9221af7729a4.png)

 
Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
