### PR TITLE
[Dominion] Fix mobile navigation

### DIFF
--- a/dominion/dominion_ui/src/components/Header/Navigation.js
+++ b/dominion/dominion_ui/src/components/Header/Navigation.js
@@ -152,7 +152,7 @@ class Navigation extends Component {
 
   renderMobileMenu() {
     const { classes, dominion, toggleModal, openModal } = this.props;
-
+    const { countries } = dominion;
     const Topbar = () => (
       <Grid
         container
@@ -187,7 +187,7 @@ class Navigation extends Component {
           <Grid container className={classes.wrapper}>
             <Topbar />
             <Search dominion={dominion}>
-              <Dropdown />
+              <Dropdown countries={countries} />
               {this.renderMenuList()}
             </Search>
           </Grid>
@@ -197,8 +197,8 @@ class Navigation extends Component {
   }
 
   renderDesktopMenu() {
-    const { classes, toggleModal, openModal } = this.props;
-
+    const { classes, toggleModal, dominion, openModal } = this.props;
+    const { countries } = dominion;
     return (
       <Grid
         container
@@ -228,6 +228,7 @@ class Navigation extends Component {
             <img alt="Search" src={searchIcon} />
           </IconButton>
           <CountriesButton
+            countries={countries}
             onClick={toggleModal('portal')}
             isOpen={openModal === 'portal'}
           />

--- a/dominion/dominion_ui/src/components/Header/Navigation.js
+++ b/dominion/dominion_ui/src/components/Header/Navigation.js
@@ -151,7 +151,7 @@ class Navigation extends Component {
   }
 
   renderMobileMenu() {
-    const { classes, toggleModal, openModal } = this.props;
+    const { classes, dominion, toggleModal, openModal } = this.props;
 
     const Topbar = () => (
       <Grid
@@ -186,7 +186,7 @@ class Navigation extends Component {
         >
           <Grid container className={classes.wrapper}>
             <Topbar />
-            <Search>
+            <Search dominion={dominion}>
               <Dropdown />
               {this.renderMenuList()}
             </Search>


### PR DESCRIPTION
## Description

While clicking menu icon on mobile view, an error occurs that breaks the entire header component.

`countries` props is not defined

This PR fixes the bug

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Bug
![Screenshot from 2019-04-14 01-35-36](https://user-images.githubusercontent.com/7962097/56085983-d4fb9780-5e55-11e9-8ad9-44c6e3fcda8c.png)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
