### PR TITLE
[Dominion] Fix Country Hero Bug

### DIFF
--- a/dominion/dominion_ui/src/components/Hero/CountryHero.js
+++ b/dominion/dominion_ui/src/components/Hero/CountryHero.js
@@ -21,6 +21,7 @@ const styles = theme => ({
     height: '250px !important',
     left: 'unset !important',
     top: 'unset !important',
+    zIndex: 100,
     [theme.breakpoints.up('md')]: {
       position: 'absolute !important',
       right: '50px',


### PR DESCRIPTION
## Description
Some part of the map are not clickable on country page, because the hero title grid is overlapping the map grid. This PR adds z-Index to the map the grid to fix it.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
### Bug
![image](https://user-images.githubusercontent.com/7962097/57430913-cc6e6500-7239-11e9-8e68-0b6311543f43.png)
### Fix
![Screenshot from 2019-05-09 09-10-32](https://user-images.githubusercontent.com/7962097/57431099-5f0f0400-723a-11e9-88f4-9ad52781d771.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
