### PR TITLE
[Hotfix] Share GA ID between Dominion & Land

### DIFF
--- a/dominion/settings.py
+++ b/dominion/settings.py
@@ -61,7 +61,7 @@ HURUMAP['email'] = 'info@codeforafrica.org'
 
 HURUMAP['github_url'] = 'https://github.com/CodeForAfrica/HURUmap-apps'
 
-HURUMAP['ga_tracking_id'] = 'UA-44795600-48'
+HURUMAP['ga_tracking_id'] = 'UA-44795600-47'
 HURUMAP['google_geocode_api_key'] = os.environ.get('GOOGLE_GEOCODE_API_KEY')
 
 HURUMAP['country_code'] = 'ZA'


### PR DESCRIPTION
## Description

Since `Dominion` and `Land` are essentially the same project, we should use the same GA id for both of these projects. Lets reuse the `Land` id since it precedes `Dominion` id.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
