### PR TITLE
[Dominion] [ZA] Fix missing North West 2016 population data

### DIFF
--- a/dominion/sql/population_group_2016.sql
+++ b/dominion/sql/population_group_2016.sql
@@ -57,10 +57,10 @@ level1	ZA_1_001	2009	Black African	9625934
 level1	ZA_1_001	2009	Coloured	134089
 level1	ZA_1_001	2009	Indian or Asian	873161
 level1	ZA_1_001	2009	White	432056
-level1	ZA_1_006	2009	Black African	3432379
-level1	ZA_1_006	2009	Coloured	61010
-level1	ZA_1_006	2009	Indian or Asian	16686
-level1	ZA_1_006	2009	White	238360
+level1	ZA_1_007	2009	Black African	3432379
+level1	ZA_1_007	2009	Coloured	61010
+level1	ZA_1_007	2009	Indian or Asian	16686
+level1	ZA_1_007	2009	White	238360
 level1	ZA_1_009	2009	Black African	10770177
 level1	ZA_1_009	2009	Coloured	443289
 level1	ZA_1_009	2009	Indian or Asian	357409


### PR DESCRIPTION
## Description

North West 2016 population data is wrongly marked as Northern Cape data in the DB. This PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/61104968-f124ca00-a480-11e9-9d68-09c7016b2019.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
